### PR TITLE
Reorder list with Raven first

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,19 +13,19 @@ interface TestItem {
 const tests: TestItem[] = [
   {
     id: '1',
-    name: 'Abilità dominante (CHC)',
-    description: 'Test perfezionato',
-    duration: '~1Gf',
-    details: 'Procedural Matrix CAT (8-12 item)',
-    slug: 'abilita-dominante-chc',
-  },
-  {
-    id: '2',
     name: 'Raven Adaptive Matrix',
     description: 'Test di ragionamento fluido',
     duration: '~10min',
     details: 'Adaptive Raven-style matrices with addition & rotation rules',
     slug: 'raven-adaptive',
+  },
+  {
+    id: '2',
+    name: 'Abilità dominante (CHC)',
+    description: 'Test perfezionato',
+    duration: '~1Gf',
+    details: 'Procedural Matrix CAT (8-12 item)',
+    slug: 'abilita-dominante-chc',
   },
   {
     id: '3',


### PR DESCRIPTION
## Summary
- reorder tests so "Raven Adaptive Matrix" appears first

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684086f4006483239c124d7b148ba723